### PR TITLE
Fix operator table padding entries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ mod fail;
 ///
 /// | Syntax     | Name           | Description                           |
 /// |------------|----------------|---------------------------------------|
-/// | ~ x        | before padding | Equivalent to `x.before_padding()`    |
-/// | x ~        | after padding  | Equivalent to `x.after_padding()`     |
+/// | ~ x        | after padding  | Equivalent to `x.after_padding()`     |
+/// | x ~        | before padding | Equivalent to `x.before_padding()`    |
 /// | x *        | any            | Equivalent to `x.repeat(..)`          |
 /// | x +        | at least one   | Equivalent to `x.repeat(1..)`         |
 /// | x ?        | optional       | Equivalent to `x.or_not()`            |


### PR DESCRIPTION
At least this is how I read the docs of `after_padding`; the padding should come *before* the `x`.