### PR TITLE
Use `Fail(..)` instead of `Self(..)`

### DIFF
--- a/src/fail.rs
+++ b/src/fail.rs
@@ -13,7 +13,7 @@ impl<E> Fail<E> {
     }
 
     pub fn map_err<G>(self, f: impl Fn(E) -> G) -> Fail<G> {
-        Self(self.0, f(self.1))
+        Fail(self.0, f(self.1))
     }
 
     #[inline(always)]


### PR DESCRIPTION
Due to a compiler bug fixed by rust-lang/rust#69340, this crate will stop compiler as discovered in https://crater-reports.s3.amazonaws.com/pr-69340/try%239ff4d07208097950831ed4ea9d76feb1eafc8baa/reg/parze-0.7.3/log.txt. This PR fixes the problem for you.